### PR TITLE
Make sure kinto-admin is installed in venv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
     - make migrate
     - .venv/bin/pip install uwsgi
 before_script:
-    - UWSGI_VIRTUALENV=.venv .venv/bin/uwsgi --http :8888 config/kinto.ini &
+    - cd $HOME && UWSGI_VIRTUALENV=$TRAVIS_BUILD_DIR/.venv $TRAVIS_BUILD_DIR/.venv/bin/uwsgi --http :8888 $TRAVIS_BUILD_DIR/config/kinto.ini &
     - autograph -c $TRAVIS_BUILD_DIR/.autograph.yml &
 script:
-    - bash smoke-test.sh
+    - bash $TRAVIS_BUILD_DIR/smoke-test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ install:
     - make migrate
     - .venv/bin/pip install uwsgi
 before_script:
-    - cd $HOME && UWSGI_VIRTUALENV=$TRAVIS_BUILD_DIR/.venv $TRAVIS_BUILD_DIR/.venv/bin/uwsgi --http :8888 $TRAVIS_BUILD_DIR/config/kinto.ini &
+    - cp $TRAVIS_BUILD_DIR/app.wsgi $HOME/
+    - cd $HOME && KINTO_INI=$TRAVIS_BUILD_DIR/config/kinto.ini UWSGI_VIRTUALENV=$TRAVIS_BUILD_DIR/.venv $TRAVIS_BUILD_DIR/.venv/bin/uwsgi --http :8888 $TRAVIS_BUILD_DIR/config/kinto.ini &
     - autograph -c $TRAVIS_BUILD_DIR/.autograph.yml &
 script:
     - bash $TRAVIS_BUILD_DIR/smoke-test.sh


### PR DESCRIPTION
Just wanted to make sure that `kinto_admin` is not available from running folder of uwsgi, in order to be sure that it gets installed.