### PR TITLE
Fix logging configuration

### DIFF
--- a/config/kinto.ini
+++ b/config/kinto.ini
@@ -209,7 +209,7 @@ kinto.logging_renderer = kinto.core.logs.MozillaHekaRenderer
 
 [loggers]
 # keys = root, sentry
-keys = root
+keys = root, kinto
 
 [handlers]
 keys = console, sentry
@@ -221,6 +221,11 @@ keys = heka, generic
 level = INFO
 handlers = console, sentry
 formatter = heka
+
+[logger_kinto]
+level = INFO
+handlers =
+qualname = kinto
 
 [logger_sentry]
 level = WARN


### PR DESCRIPTION
Without that, running `kinto --ini config/kinto.ini start` does not show logging output of kinto app/plugins...

@Natim r?