### PR TITLE
Make sure we use a supported version of pyramid.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ README = read_file('README.rst')
 CHANGELOG = read_file('CHANGELOG.rst')
 
 REQUIREMENTS = [
+    "pyramid>1.7,<1.8",
     "kinto[postgresql,monitoring]>=5.1,<5.2",
     "kinto-attachment>=1.0,<1.1",
     "kinto-amo>=0.3.0,<0.4",


### PR DESCRIPTION
For some reason `repoze.send_mail` is installing `pyramid==1.8a1` as a dependency. This is to ensure we are using pyramid 1.7.3 until kinto supports pyramid 1.8