### PR TITLE
Mention kinto-changes on readonly stacks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ the version control of each dependency.
 Configuration Breaking Changes
 ''''''''''''''''''''''''''''''
 
+* ``kinto_changes`` must now be present in ``kinto.includes`` (eg. on read-only stacks)
+  otherwise the monitoring endpoint won't be accessible.
+* The configuration of *kinto-changes* has to be changed:
+
 Before:
 
 .. code-block :: ini


### PR DESCRIPTION
The configuration breaking changes on the future kinto-dist 2.0 did not mention that kinto-changes must be included on readonly stacks in order to expose the monitoring endpoint.