### PR TITLE
Add mozilla-cloud-services-logger to requirements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,10 +5,10 @@ This document describes changes between each past release as well as
 the version control of each dependency.
 
 
-3.1.0 (unreleased)
+3.0.1 (2017-06-12)
 ==================
 
-- Nothing changed yet.
+- Install mozilla-cloud-services-logger. (#134)
 
 
 3.0.0 (2017-06-12)

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,7 @@ logging-color-formatter==1.0.2
 lxml==3.8.0
 MarkupSafe==1.0
 mohawk==0.3.4
+mozilla-cloud-services-logger==1.0.1
 newrelic==2.86.3.70
 PasteDeploy==1.5.2
 psycopg2==2.7.1

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ REQUIREMENTS = [
     "kinto-ldap>=0.3.0,<0.4",
     "amo2kinto>=2.0,<2.1",
     "boto>=2.46,<2.47",
+    "mozilla-cloud-services-logger>=1.0,<1.1",
 ]
 ENTRY_POINTS = {}
 DEPENDENCY_LINKS = []

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ ENTRY_POINTS = {}
 DEPENDENCY_LINKS = []
 
 setup(name='kinto-dist',
-      version='3.1.0.dev0',
+      version='3.0.1',
       description='Kinto Distribution',
       long_description=README + "\n\n" + CHANGELOG,
       license='Apache License (2.0)',


### PR DESCRIPTION
Needed for:

```
[formatter_json]
class = mozilla_cloud_services_logger.formatters.JsonLogFormatter
```