### PR TITLE
Prepare 4.0.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ This document describes changes between each past release as well as
 the version control of each dependency.
 
 
-4.0.1 (unreleased)
+4.0.1 (2017-08-14)
 ==================
 
 kinto

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,10 +5,28 @@ This document describes changes between each past release as well as
 the version control of each dependency.
 
 
-4.1.0 (unreleased)
+4.0.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+kinto
+'''''
+
+**kinto 7.3.1 → 7.3.2**: https://github.com/Kinto/kinto/releases/tag/7.3.2
+
+**Bug fixes**
+
+- The PostgreSQL cache backend now orders deletes according to keys,
+  which are a well-defined order that never changes. (Fixes #1308.)
+
+**Internal changes**
+
+- Now all configuration options appear as commented lines on the configuration
+  template (#895)
+- Added task on PR template about updating the configuration template
+  if a new configuration setting is added.
+- Use json instead of ujson in storage in tests (#1255)
+- Improve Docker container to follow Dockerflow recommendations (fixes #998)
+
 
 
 4.0.0 (2017-08-09)

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ jmespath==0.9.3
 jsonpatch==1.16
 jsonpointer==1.10
 jsonschema==2.6.0
-kinto==7.3.1
+kinto==7.3.2
 kinto-amo==0.4.0
 kinto-attachment==2.0.1
 kinto-changes==1.0.0

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ ENTRY_POINTS = {}
 DEPENDENCY_LINKS = []
 
 setup(name='kinto-dist',
-      version='4.1.0.dev0',
+      version='4.0.1',
       description='Kinto Distribution',
       long_description=README + "\n\n" + CHANGELOG,
       license='Apache License (2.0)',


### PR DESCRIPTION
## kinto

**kinto 7.3.1 → 7.3.2**: https://github.com/Kinto/kinto/releases/tag/7.3.2

**Bug fixes**

- The PostgreSQL cache backend now orders deletes according to keys,
  which are a well-defined order that never changes. (Fixes #1308.)

**Internal changes**

- Now all configuration options appear as commented lines on the configuration
  template (#895)
- Added task on PR template about updating the configuration template
  if a new configuration setting is added.
- Use json instead of ujson in storage in tests (#1255)
- Improve Docker container to follow Dockerflow recommendations (fixes #998)
