### PR TITLE
Prepare release 6.0.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ CHANGELOG
 This document describes changes between each past release as well as
 the version control of each dependency.
 
-6.0.1 (unreleased)
+6.0.1 (2018-03-28)
 ==================
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,29 @@ CHANGELOG
 This document describes changes between each past release as well as
 the version control of each dependency.
 
+6.0.1 (unreleased)
+==================
+
+
+kinto
+'''''
+
+**kinto 8.2.0 → 8.2.2**: https://github.com/Kinto/kinto/releases/tag/8.2.2
+
+**Internal changes**
+
+- Upgrade to kinto-admin 1.15.1
+
+
+kinto-admin
+'''''''''''
+
+**kinto-admin 1.15.0 → 1.15.1**: https://github.com/Kinto/kinto-admin/releases/tag/v1.15.1
+
+**Bug fixes**
+
+- [signoff] Fix bug where users who are part of "editors" and "reviewers" groups do not get shown the "request review" or "approve" buttons (Kinto/kinto-admin#495)
+
 
 6.0.0 (2018-03-09)
 ==================

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ jmespath==0.9.3
 jsonpatch==1.21
 jsonpointer==2.0
 jsonschema==2.6.0
-kinto==8.2.0
+kinto==8.2.2
 kinto-amo==1.0.1
 kinto-attachment==2.1.0
 kinto-changes==1.1.0

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ ENTRY_POINTS = {}
 DEPENDENCY_LINKS = []
 
 setup(name='kinto-dist',
-      version='6.0.0',
+      version='6.0.1',
       description='Kinto Distribution',
       long_description=README + "\n\n" + CHANGELOG,
       license='Apache License (2.0)',

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ CHANGELOG = read_file('CHANGELOG.rst')
 
 REQUIREMENTS = [
     "pyramid>=1.9.1,<2.0",
-    "kinto[postgresql,memcached,monitoring]>=8.2,<9.0",
+    "kinto[postgresql,memcached,monitoring]>=8.2.2,<9.0",
     "kinto-attachment>=2.1,<2.2",
     "kinto-amo>=1.0.1,<1.1.0",
     "kinto-changes>=1.1.0,<1.2.0",


### PR DESCRIPTION
This is a bug fix release for 6.0.0 where we only upgrade kinto-admin from 1.15.0 to 1.15.1 to fix https://github.com/Kinto/kinto-admin/issues/495