### PR TITLE
Upgrade to kinto 8.2.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,15 @@ the version control of each dependency.
 6.0.2 (unreleased)
 ==================
 
-- Nothing changed yet.
+kinto
+'''''
+
+**kinto 8.2.2 → 8.2.3**: https://github.com/Kinto/kinto/releases/tag/8.2.3
+
+**Security fix**
+
+- Since Kinto 8.2.0 the `account` plugin had a security flaw where the password wasn't verified during the session duration.
+  It now validates the account user password even when the session is cached (Kinto/kinto#1583).
 
 
 6.0.1 (2018-03-28)

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ jmespath==0.9.3
 jsonpatch==1.21
 jsonpointer==2.0
 jsonschema==2.6.0
-kinto==8.2.2
+kinto==8.2.3
 kinto-amo==1.0.1
 kinto-attachment==2.1.0
 kinto-changes==1.1.0

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ CHANGELOG = read_file('CHANGELOG.rst')
 
 REQUIREMENTS = [
     "pyramid>=1.9.1,<2.0",
-    "kinto[postgresql,memcached,monitoring]>=8.2.2,<9.0",
+    "kinto[postgresql,memcached,monitoring]>=8.2.3,<9.0",
     "kinto-attachment>=2.1,<2.2",
     "kinto-amo>=1.0.1,<1.1.0",
     "kinto-changes>=1.1.0,<1.2.0",


### PR DESCRIPTION
AFAIK We don't have any kinto-dist 6.0.X running the `account` plugin in production 