### PR TITLE
[do-not-merge] Preparing release 7.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ CHANGELOG
 This document describes changes between each past release as well as
 the version control of each dependency.
 
-6.1.0 (unreleased)
+7.0.0 (2018-04-25)
 ==================
 
 kinto-signer

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ ENTRY_POINTS = {}
 DEPENDENCY_LINKS = []
 
 setup(name='kinto-dist',
-      version='6.1.0.dev0',
+      version='7.0.0',
       description='Kinto Distribution',
       long_description=README + "\n\n" + CHANGELOG,
       license='Apache License (2.0)',


### PR DESCRIPTION
Since we bumped a major (breaking changes in kinto-attachments) we can wait for kinto 9 to be released  https://github.com/Kinto/kinto/pull/1611
