### PR TITLE
[WIP] Allow to override the INI location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN groupadd -g 9000 kinto && \
 COPY . /app
 WORKDIR /app
 
+ENV KINTO_INI /etc/kinto.ini
+
 RUN buildDeps=' \
     git \
     gcc \
@@ -34,4 +36,4 @@ RUN buildDeps=' \
 USER kinto
 
 # Run uwsgi by default
-CMD ["uwsgi", "--ini", "/etc/kinto.ini"]
+CMD ["uwsgi", "--ini", "${KINTO_INI}"]


### PR DESCRIPTION
Does not work...


````
$docker run -v `pwd`/rsconf:/etc \
               -e KINTO_INI=/etc/rsconf/server.ini \
               -p 8888:8888 \
               c1e32713cd39
realpath() of ${KINTO_INI} failed: No such file or directory [core/utils.c line 3643]

````