### PR TITLE
Put back git and openssh-client

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       - run:
           name: Install essential packages
           command: |
-            apt-get update && apt-get install -y ca-certificates curl
+            apt-get update && apt-get install -y ca-certificates curl git openssh-client
 
       - checkout
 


### PR DESCRIPTION
Some CircleCI builds failed when building an annotated tag. See for
instance
https://circleci.com/gh/mozilla-services/kinto-dist/647. Builds seem
to succeed on non-annotated lightweight tags, but annotated tags are
more correct for doing releases. I believe this is because of bugs in
the CircleCI built-in git/ssh support and hope that restoring these
packages will cause the problem to go away.