### PR TITLE
Preparing release 10.0.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ CHANGELOG
 This document describes changes between each past release as well as
 the version control of each dependency.
 
-10.0.1 (unreleased)
+10.0.1 (2018-10-04)
 ===================
 
 kinto

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ CHANGELOG = read_file('CHANGELOG.rst')
 
 setup(
     name='kinto-dist',
-    version='10.0.1.dev0',
+    version='10.0.1',
     description='Kinto Distribution',
     long_description=README + "\n\n" + CHANGELOG,
     license='Apache License (2.0)',


### PR DESCRIPTION
This version only ships the bug fix for OpenID Connect authentication. 

It shouldn't be long before we ship the new Kinto Admin with the ton of other bug fixes and improvements.