### PR TITLE
list all known Mozilla instances

### DIFF
--- a/Known-Instances.yml
+++ b/Known-Instances.yml
@@ -1,0 +1,12 @@
+# The purpose of this file is to get a list of all known Mozilla
+# instance of kinto-dist.
+# This file is manually maintained. To add a URL, make pull request on
+# this file.
+
+instances:
+  Buildhub:
+    - https://buildhub.prod.mozaws.net/v1/__version__
+  Webextensions:
+    - https://webextensions.settings.services.mozilla.com/v1/__version__
+  RemoteSettings:
+    - https://firefox.settings.services.mozilla.com/v1/__version__

--- a/README.rst
+++ b/README.rst
@@ -265,3 +265,12 @@ Then:
 
 - Create a release on the Github page using the contents of the CHANGELOG as the body
 - Open a Bugzilla bug telling ops to deploy the new release
+
+Known Instances
+---------------
+
+To know all places where we use ``kinto-dist`` we maintain a list of in a
+machine readable file ``Kinto-Instances.yml``.
+
+Use that to update URLs of instances of ``kinto-dist``. It can be leveraged
+for automation (e.g. places to upgrade) and auditing.


### PR DESCRIPTION
I tested it like this :)

```
>>> from yaml import load
>>> d = load(open('Known-Instances.yml'))
>>> from pprint import pprint
>>> pprint(d)
{'instances': {'Buildhub': ['https://buildhub.prod.mozaws.net/v1/__version__'],
               'RemoteSettings': ['https://firefox.settings.services.mozilla.com/v1/__version__'],
               'Webextensions': ['https://webextensions.settings.services.mozilla.com/v1/__version__']}}
>>>
```

