### PR TITLE
Don't loop forever

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
           command: |
             # Megaphone can take an arbitrary amount of time to start
             # up (probably waiting for mysql to accept connections)
-            until docker-compose run tests http --check-status "http://megaphone:8000/__heartbeat__"; do date; docker logs kintodist_megaphone_1 | tail; sleep 1; done
+            x=0; until docker-compose run tests http --check-status "http://megaphone:8000/__heartbeat__" || [ $x -gt 10 ]; do date; sleep 1; echo $((x += 1)); done; if [ $x -eq 10 ]; then docker logs kintodist_megaphone_1; fi
 
       - run:
           name: Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,10 @@ jobs:
             docker-compose run web migrate
 
       - run:
+          name: Env
+          command: docker-compose run megaphone env
+
+      - run:
           name: Wait for megaphone
           command: |
             # Megaphone can take an arbitrary amount of time to start


### PR DESCRIPTION
Currently, the hacky changes I stuck in the CircleCI config cause the build to get stuck in an infinite loop when Megaphone doesn't come up. This is making it difficult to get actual work done while we debug what's going on. This PR adds a couple commits to try to cause failures to be timely again, as well as trying to maybe see a little bit more about what's causing the Megaphone failure.