### PR TITLE
Pin megaphone

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
           command: |
             # Megaphone can take an arbitrary amount of time to start
             # up (probably waiting for mysql to accept connections)
-            x=0; until docker-compose run tests http --check-status "http://megaphone:8000/__heartbeat__" || [ $x -gt 10 ]; do date; sleep 1; echo $((x += 1)); done; if [ $x -eq 10 ]; then docker logs kintodist_megaphone_1; fi
+            x=0; until docker-compose run tests http --check-status "http://megaphone:8000/__heartbeat__" || [ $x -gt 10 ]; do date; sleep 1; echo $((x += 1)); done; if [ $x -gt 10 ]; then docker logs kintodist_megaphone_1; fi
 
       - run:
           name: Tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     image: kinto:autograph
 
   megaphone:
-    image: mozilla/megaphone
+    image: mozilla/megaphone:0.1.5
     depends_on:
       - mysql
     environment:


### PR DESCRIPTION
Replaces #494, which has gone on for a while and been through some surprising plot twists. Here's the current state of play.

We've been hitting some intermittent build failures with megaphone failing to come up in the CI. Based on the gnomic comments of the Push team in e.g. https://github.com/mozilla-services/megaphone/pull/68, it seems like this was a bug introduced by https://github.com/mozilla-services/megaphone/pull/63, which bumped the Rocket dependency and caused it to behave differently on calls to `get_bool`. This should be an "always" error rather than intermittent, but I guess CircleCI caches images based on their tags, so probably some CircleCI machines were running a `megaphone:latest` that didn't have the bug and some that did, and the intermittency was due to jobs being assigned to different machines.

This happens to point to a larger issue with our `docker-compose.yml` file, which is that the versions for dependent services are kind of haphazard. Really our goal should be to pin to what we are running (or about-to-be-running) in production. To that end, Peter has opened #499 and #500. It turns out that the issue that we hit was introduced after 0.1.5 (the latest version currently available on DockerHub), so pinning to that should make the intermittency go away, and also bring us a tiny bit closer to matching whatever's in prod. In case the intermittency doesn't go away, let's also fix the shoddy bash scripting I did so that we see logs on the next failure.