### PR TITLE
Pin machine image to an older version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ version: 2
 jobs:
   build_test_publish:
     machine:
+      image: circleci/classic:201710-01
       docker_layer_caching: true
 
     working_directory: ~/kinto-dist


### PR DESCRIPTION
Per
https://discuss.circleci.com/t/cannot-install-php-7-1-on-machine-because-of-locked-var-lib-dpkg-lock-file/24639/17,
there seems to be something wrong with CircleCI's image
circleci/classic:201808-01. We don't specify an image, which means
we're getting the "default" image, which *should* be this older one,
but maybe it changed recently.