### PR TITLE
Prepare 21.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ This document describes changes between each past release as well as
 the version control of each dependency.
 
 
-21.1.0 (unreleased)
+21.1.0 (2020-09-23)
 ===================
 
 kinto-changes

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,12 @@ This document describes changes between each past release as well as
 the version control of each dependency.
 
 
+21.1.0 (unreleased)
+===================
+
+- Nothing changed yet.
+
+
 21.0.0 (2020-09-16)
 ===================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,19 @@ the version control of each dependency.
 21.1.0 (unreleased)
 ===================
 
-- Nothing changed yet.
+kinto-changes
+-------------
+
+**kinto-changes 3.0.2 → 3.1.0**: https://github.com/Kinto/kinto-changes/releases/tag/3.1.0
+
+**New features**
+
+- Redirect clients whose ``?_since`` value is too old (21 days by default)
+- Add support for monitor/changes in changeset endpoints (fixes #173)
+
+**Bug fixes**
+
+- Fix validation rule for ``_since`` query parameter
 
 
 21.0.0 (2020-09-16)

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -10,9 +10,9 @@ kinto-attachment==6.1.0 \
 kinto-amo==1.0.1 \
     --hash=sha256:5601bc1f0d8c71f12b89862d3c82bcca4380b3fec8824919b01b6e52bbed6d69 \
     --hash=sha256:cb8520bbbba0df6413350f03c048afacb0922f73c02804e89ceccc45d1ed4e5b
-kinto-changes==3.0.2 \
-    --hash=sha256:46c648ff14fb5f5fc7c3df0c25a6483daab7218e6e6c15b6e4d8f59613516325 \
-    --hash=sha256:a057531f3c40df1e1377d45208cf3806a4b322c9cf6fae4a79a28faa6b9c66e5
+kinto-changes==3.1.0 \
+    --hash=sha256:c6ed042c0de3ae50c4a9e1ef6a70c7793900d527bcc4cfc7db936fe9270397c2 \
+    --hash=sha256:ff27944e5a28746aa1536f11ebec3fba09478a1d72cf2c93575e8d15e8424c0c
 kinto-elasticsearch==0.3.1 \
     --hash=sha256:0315227738cf08fbe532330bc4fac9c963e4b688041de6fc042be04af7597870 \
     --hash=sha256:25300a270ef2fc96e2391bb128cdb75e520b1b6ce2a26f7766e19785dce70f5d

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ INSTALL_REQUIRES = [
 
 setup(
     name='kinto-dist',
-    version='21.1.0.dev0',
+    version='21.1.0',
     description='Kinto Distribution',
     long_description=README + "\n\n" + CHANGELOG,
     license='Apache License (2.0)',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ INSTALL_REQUIRES = [
 
 setup(
     name='kinto-dist',
-    version='21.0.0',
+    version='21.1.0.dev0',
     description='Kinto Distribution',
     long_description=README + "\n\n" + CHANGELOG,
     license='Apache License (2.0)',


### PR DESCRIPTION
This release introduces the redirection for client reaching monitor/changes with an old _since value (see https://bugzilla.mozilla.org/show_bug.cgi?id=1665319)