### PR TITLE
Remove kinto-megaphone from distribution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,18 +50,6 @@ jobs:
             docker-compose run web migrate
 
       - run:
-          name: Env
-          command: docker-compose run megaphone env
-
-      - run:
-          name: Wait for megaphone
-          command: |
-            # Megaphone can take an arbitrary amount of time to start
-            # up (probably waiting for mysql to accept connections)
-            wget -q --tries=30 --retry-connrefused --waitretry=1 -O /dev/null "http://localhost:5555/__heartbeat__"
-            docker logs megaphone
-
-      - run:
           name: Tests
           command: |
               docker-compose run tests start

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,15 @@ CHANGELOG
 This document describes changes between each past release as well as
 the version control of each dependency.
 
+
+25.0.0 (unreleased)
+===================
+
+**Breaking Changes**
+
+- Removed ``kinto_megaphone`` from packages distribution
+
+
 24.0.1 (2021-10-18)
 ===================
 

--- a/config/example.ini
+++ b/config/example.ini
@@ -140,7 +140,6 @@ kinto.includes = kinto.plugins.default_bucket
                  kinto_emailer
                  kinto_attachment
                  kinto_signer
-                 kinto_megaphone
 #                kinto_redis
 #                kinto_fxa
 #                kinto.plugins.quotas
@@ -207,17 +206,6 @@ mail.debug_mailer = true
 # mail.debug = 0
 # mail.sendmail_app = /usr/sbin/sendmail
 # mail.sendmail_template = {sendmail_app} -t -i -f {sender}
-
-#
-# Kinto megaphone
-#
-event_listeners = mp
-event_listeners.mp.use = kinto_megaphone.listeners
-event_listeners.mp.url = http://megaphone:8000/
-event_listeners.mp.api_key = token1
-event_listeners.mp.broadcaster_id = kinto-dist-test
-event_listeners.mp.match_kinto_changes = /buckets/blog/collections/articles
-
 
 
 [uwsgi]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,28 +20,6 @@ services:
     volumes:
       - ${PWD}/autograph/autograph.yaml:/app/autograph.yaml
 
-  megaphone:
-    image: mozilla/megaphone:0.1.6
-    container_name: megaphone
-    depends_on:
-      - mysql
-    environment:
-      ROCKET_DATABASE_URL: mysql://megaphone-user:megaphone-pass@mysql/megaphone
-      ROCKET_BROADCASTER_AUTH: "{kinto-dist-test=[token1]}"
-      ROCKET_READER_AUTH: "{reader=[token2]}"
-      ROCKET_LOG: normal
-      RUST_BACKTRACE: 1
-    ports:
-      - "5555:8000"
-
-  mysql:
-    image: mysql:5
-    environment:
-      MYSQL_ROOT_PASSWORD: mysql-root-pass
-      MYSQL_DATABASE: megaphone
-      MYSQL_USER: megaphone-user
-      MYSQL_PASSWORD: megaphone-pass
-
   web:
     build:
       context: .
@@ -51,14 +29,12 @@ services:
       - db
       - memcached
       - autograph
-      - megaphone
     environment:
       - KINTO_CACHE_BACKEND=kinto.core.cache.memcached
       - KINTO_CACHE_HOSTS=memcached:11211 memcached:11212
       - KINTO_STORAGE_URL=postgresql://postgres@db/postgres
       - KINTO_PERMISSION_URL=postgresql://postgres@db/postgres
       - KINTO_SIGNER_AUTOGRAPH_SERVER_URL=http://autograph:8000
-      # - Megaphone is configured in config/example.ini (see event_listeners)
     ports:
       - "8888:8888"
     volumes:

--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,6 @@ kinto-changes
 kinto-elasticsearch
 kinto-emailer
 kinto-signer
-kinto-megaphone
 kinto-fxa
 boto
 python-memcached

--- a/requirements.txt
+++ b/requirements.txt
@@ -245,7 +245,6 @@ kinto[monitoring,postgresql]==14.5.1 \
     #   kinto-elasticsearch
     #   kinto-emailer
     #   kinto-fxa
-    #   kinto-megaphone
     #   kinto-redis
     #   kinto-signer
 kinto-attachment==6.1.0 \
@@ -255,9 +254,7 @@ kinto-attachment==6.1.0 \
 kinto-changes==3.2.0 \
     --hash=sha256:2df50b6461a4d3066d5d69d111a7a8c5fd26fa22ba1ad8d457708ce088c392fb \
     --hash=sha256:ac8475cc6d76cd18b7677bc6178d1afc8f0b4f0df9145d0d012ea98cc08a655f
-    # via
-    #   -r requirements.in
-    #   kinto-megaphone
+    # via -r requirements.in
 kinto-elasticsearch==0.3.1 \
     --hash=sha256:0315227738cf08fbe532330bc4fac9c963e4b688041de6fc042be04af7597870 \
     --hash=sha256:25300a270ef2fc96e2391bb128cdb75e520b1b6ce2a26f7766e19785dce70f5d
@@ -268,10 +265,6 @@ kinto-emailer==2.0.0 \
 kinto-fxa==2.5.3 \
     --hash=sha256:86878cc3c3e93dfabd3298e3a7e557aa15bd92328902d8197b57bf6c9eda0c52 \
     --hash=sha256:927b8bf6365a8f5d898e46428a2888d4007641b7e8de59aa37488cfebf22b3a8
-    # via -r requirements.in
-kinto-megaphone==0.5.0 \
-    --hash=sha256:d9cb79bf6ff02a42e1744c086fcdfc966e1a6a81559d14ad86fe9656f781b27a \
-    --hash=sha256:f5d89198ca382712006eeb6fea71ddace3f358e61fb4e932d7081d7e81cccfd8
     # via -r requirements.in
 kinto-redis==2.0.1 \
     --hash=sha256:f1a7147e16b6d83abe24a3ef32e0c7f3f48880ad60f88ae832e225f225cf6903
@@ -439,7 +432,6 @@ requests==2.25.1 \
     # via
     #   ec2-metadata
     #   kinto
-    #   kinto-megaphone
     #   pybrowserid
     #   pyfxa
     #   requests-hawk


### PR DESCRIPTION
Since [Nov 2020](https://github.com/mozilla-services/cloudops-deployment/pull/4112), the push notification is sent via [an AWS lambda](https://github.com/mozilla-services/remote-settings-lambdas/#sync_megaphone) (https://github.com/mozilla-services/cloudops-deployment/pull/4111).

See also https://github.com/Kinto/kinto-changes/pull/287