### PR TITLE
Move signer notification setup from top-level to signer plugin

### DIFF
--- a/kinto_remote_settings/__init__.py
+++ b/kinto_remote_settings/__init__.py
@@ -1,15 +1,3 @@
-from .signer.events import ReviewApproved, ReviewRejected, ReviewRequested
-
-
 def includeme(config):
     config.include("kinto_remote_settings.changes")
     config.include("kinto_remote_settings.signer")
-
-    try:
-        from kinto_emailer import send_notification
-
-        config.add_subscriber(send_notification, ReviewRequested)
-        config.add_subscriber(send_notification, ReviewApproved)
-        config.add_subscriber(send_notification, ReviewRejected)
-    except ImportError:
-        pass

--- a/kinto_remote_settings/signer/__init__.py
+++ b/kinto_remote_settings/signer/__init__.py
@@ -2,7 +2,7 @@ import copy
 import functools
 import re
 
-from .events import ReviewApproved
+from .events import ReviewApproved, ReviewRejected, ReviewRequested
 
 DEFAULT_SIGNER = "kinto_remote_settings.signer.backends.local_ecdsa"
 
@@ -264,3 +264,12 @@ def includeme(config):
         current.addBeforeCommitHook(listeners.send_signer_events, args=(event,))
 
     config.add_subscriber(on_new_request, NewRequest)
+
+    try:
+        from kinto_emailer import send_notification
+
+        config.add_subscriber(send_notification, ReviewRequested)
+        config.add_subscriber(send_notification, ReviewApproved)
+        config.add_subscriber(send_notification, ReviewRejected)
+    except ImportError:
+        pass

--- a/kinto_remote_settings/signer/tests/config/signer.ini
+++ b/kinto_remote_settings/signer/tests/config/signer.ini
@@ -11,6 +11,7 @@ multiauth.policies = basicauth
 kinto.includes = kinto_remote_settings.signer
                  kinto.plugins.history
                  kinto.plugins.flush
+                 kinto_emailer
 
 signer.group_check_enabled = true
 signer.to_review_enabled = true


### PR DESCRIPTION
Done so that we can include `signer` and `changes` together as `kinto_remote_changes` in some cases (such as the example config in this repo), and separately as `kinto_remote_changes.signer` and/or `kinto_remote_changes.changes` in others.