### PR TITLE
Get rid of group_check_enabled setting

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,17 @@ CHANGELOG
 This document describes changes between each past release as well as
 the version control of each dependency.
 
+
+26.0.0 (unreleased)
+===================
+
+**Breaking Changes**
+
+
+- The ``kinto.signer.group_check_enabled`` setting is now always ``true``, and
+  won't be read from configuration anymore.
+
+
 26.0.0 (2021-12-01)
 ===================
 

--- a/config/example.ini
+++ b/config/example.ini
@@ -155,7 +155,6 @@ kinto.signer.resources = /buckets/source -> /buckets/preview -> /buckets/destina
 kinto.signer.editors_group = {collection_id}-editors
 kinto.signer.reviewers_group = {collection_id}-reviewers
 
-kinto.signer.group_check_enabled = true
 kinto.signer.to_review_enabled = true
 kinto.signer.signer_backend = kinto_remote_settings.signer.backends.autograph
 

--- a/kinto_remote_settings/signer/__init__.py
+++ b/kinto_remote_settings/signer/__init__.py
@@ -95,7 +95,6 @@ def includeme(config):
         "reviewers_group": "reviewers",
         "editors_group": "editors",
         "to_review_enabled": False,
-        "group_check_enabled": False,
     }
     global_settings = {}
     for setting in listeners.REVIEW_SETTINGS:

--- a/kinto_remote_settings/signer/listeners.py
+++ b/kinto_remote_settings/signer/listeners.py
@@ -16,7 +16,6 @@ REVIEW_SETTINGS = (
     "reviewers_group",
     "editors_group",
     "to_review_enabled",
-    "group_check_enabled",
 )
 
 
@@ -248,7 +247,6 @@ def send_signer_events(event):
 def check_collection_status(
     event,
     resources,
-    group_check_enabled,
     to_review_enabled,
     editors_group,
     reviewers_group,
@@ -281,7 +279,6 @@ def check_collection_status(
 
         # to-review and group checking.
         _to_review_enabled = resource.get("to_review_enabled", to_review_enabled)
-        _group_check_enabled = resource.get("group_check_enabled", group_check_enabled)
         _editors_group = resource_group(
             resource, "editors_group", default=editors_group
         )
@@ -310,7 +307,7 @@ def check_collection_status(
 
         # 2. work-in-progress -> to-review
         elif new_status == STATUS.TO_REVIEW:
-            if editors_group_uri not in user_principals and _group_check_enabled:
+            if editors_group_uri not in user_principals:
                 raise_forbidden(message="Not in %s group" % _editors_group)
 
         # 3. to-review -> work-in-progress
@@ -322,7 +319,7 @@ def check_collection_status(
                 raise_invalid(message="Collection already signed")
 
             # Only allow to-sign from to-review if reviewer and no-editor
-            if reviewers_group_uri not in user_principals and _group_check_enabled:
+            if reviewers_group_uri not in user_principals:
                 raise_forbidden(message="Not in %s group" % _reviewers_group)
 
             if old_status != STATUS.TO_REVIEW and _to_review_enabled:

--- a/kinto_remote_settings/signer/tests/config/signer.ini
+++ b/kinto_remote_settings/signer/tests/config/signer.ini
@@ -13,7 +13,6 @@ kinto.includes = kinto_remote_settings.signer
                  kinto.plugins.flush
                  kinto_emailer
 
-signer.group_check_enabled = true
 signer.to_review_enabled = true
 
 kinto.signer.resources =

--- a/kinto_remote_settings/signer/tests/functional.py
+++ b/kinto_remote_settings/signer/tests/functional.py
@@ -121,7 +121,6 @@ class BaseTestFunctional(object):
 
     def test_groups_and_reviewers_are_forced(self):
         capability = self.source.server_info()["capabilities"]["signer"]
-        assert capability["group_check_enabled"]
         assert capability["to_review_enabled"]
 
     def test_heartbeat_is_successful(self):

--- a/kinto_remote_settings/signer/tests/support.py
+++ b/kinto_remote_settings/signer/tests/support.py
@@ -30,6 +30,5 @@ class BaseWebTest(CoreWebTest):
         config = configparser.ConfigParser()
         config.read(ini_path)
         settings = dict(config.items("app:main"))
-        settings["signer.group_check_enabled"] = False
         settings["signer.to_review_enabled"] = False
         return settings

--- a/kinto_remote_settings/signer/tests/test_events.py
+++ b/kinto_remote_settings/signer/tests/test_events.py
@@ -56,6 +56,15 @@ class ResourceEventsTest(BaseWebTest, unittest.TestCase):
     def setUp(self):
         super().setUp()
         self.app.put_json("/buckets/alice", headers=self.headers)
+
+        resp = self.app.get("/", headers=self.headers)
+        self.userid = resp.json["user"]["id"]
+        self.app.put_json(
+            "/buckets/alice/groups/reviewers",
+            {"data": {"members": [self.userid]}},
+            headers=self.headers,
+        )
+
         self.app.put_json(self.source_collection, headers=self.headers)
         self.app.post_json(
             self.source_collection + "/records",
@@ -389,6 +398,15 @@ class SignoffEventsTest(BaseWebTest, unittest.TestCase):
         del self.events[:]
 
         self.app.put_json("/buckets/alice", headers=self.headers)
+
+        resp = self.app.get("/", headers=self.headers)
+        self.userid = resp.json["user"]["id"]
+        self.app.put_json(
+            "/buckets/alice/groups/reviewers",
+            {"data": {"members": [self.userid]}},
+            headers=self.headers,
+        )
+
         self.app.put_json(self.source_collection, headers=self.headers)
         self.app.post_json(
             self.source_collection + "/records",

--- a/kinto_remote_settings/signer/tests/test_signer_attachments.py
+++ b/kinto_remote_settings/signer/tests/test_signer_attachments.py
@@ -65,7 +65,6 @@ class SignerAttachmentsTest(BaseWebTest, unittest.TestCase):
         )
 
         settings["signer.to_review_enabled"] = "false"
-        settings["signer.group_check_enabled"] = "false"
 
         settings["attachment.base_path"] = "/tmp"
 

--- a/kinto_remote_settings/signer/tests/test_signoff_flow.py
+++ b/kinto_remote_settings/signer/tests/test_signoff_flow.py
@@ -986,7 +986,7 @@ class SpecificUserGroupsTest(SignoffWebTest, FormattedErrorMixin, unittest.TestC
             headers=self.headers,
         )
 
-    def test_editors_cannot_ask_to_review_if_not_specificly_configured(self):
+    def test_editors_cannot_ask_to_review_if_not_specifically_configured(self):
         resp = self.app.patch_json(
             self.source_collection2,
             {"data": {"status": "to-review"}},


### PR DESCRIPTION
Now that kinto-signer is remote-settings, we can remove some unnecessary configuration. 
Group check is always enabled, we don't have any use-cases for group-less behavior. 