### PR TITLE
Tweak CI - Cache dependencies and require linting to pass before other jobs run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,16 @@
 # DOCKER_PASS
 #
 version: 2.1
+aliases:
+  - &restore_deps_cache
+      name: Restoring Python dependency cache
+      key: v1-requirements-{{ checksum "requirements.txt" }}
+
+  - &save_deps_cache
+      name: Saving Python dependency cache
+      key: v1-requirements-{{ checksum "requirements.txt" }}
+      paths:
+        - .venv
 jobs:
   build_and_publish:
     machine:
@@ -109,17 +119,21 @@ jobs:
     working_directory: ~/kinto-dist
     steps:
       - checkout
+      - restore_cache: *restore_deps_cache
       - run:
           name: Run kinto_remote_settings plugin unit tests
           command: make test
+      - save_cache: *save_deps_cache
   lint_format:
     docker:
       - image: cimg/python:3.9
     steps:
       - checkout
+      - restore_cache: *restore_deps_cache
       - run:
           name: Check linting and formatting
           command: make lint
+      - save_cache: *save_deps_cache
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,11 +8,11 @@ version: 2.1
 aliases:
   - &restore_deps_cache
       name: Restoring Python dependency cache
-      key: v1-requirements-{{ checksum "requirements.txt" }}
+      key: v1-requirements-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
 
   - &save_deps_cache
       name: Saving Python dependency cache
-      key: v1-requirements-{{ checksum "requirements.txt" }}
+      key: v1-requirements-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
       paths:
         - .venv
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,6 +125,13 @@ workflows:
   version: 2
   main:
     jobs:
+      - lint_format
+      - integration_test:
+          requires:
+            - lint_format
+      - unit_test:
+          requires:
+            - lint_format
       - build_and_publish:
           requires:
             - unit_test
@@ -132,6 +139,3 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - integration_test
-      - unit_test
-      - lint_format

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,6 @@ jobs:
           POSTGRES_DB: testdb
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-    working_directory: ~/kinto-dist
     steps:
       - checkout
       - restore_cache: *restore_deps_cache

--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,10 @@ lint: $(INSTALL_STAMP)
 	$(VENV)/bin/black --check kinto-remote-settings tests --diff
 	$(VENV)/bin/flake8 kinto-remote-settings tests
 
-test: $(INSTALL_STAMP) lint
+test: $(INSTALL_STAMP)
 	PYTHONPATH=. $(VENV)/bin/pytest kinto-remote-settings
 
-integration-test: $(INSTALL_STAMP) lint
+integration-test: $(INSTALL_STAMP)
 	docker-compose run web migrate
 	docker-compose run tests
 

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ lint: $(INSTALL_STAMP)
 test: $(INSTALL_STAMP)
 	PYTHONPATH=. $(VENV)/bin/pytest kinto-remote-settings
 
-integration-test: $(INSTALL_STAMP)
+integration-test:
 	docker-compose run web migrate
 	docker-compose run tests
 


### PR DESCRIPTION
- Require `lint_format` to pass before unit / integration tests are run
- Cache Python dependencies to help `lint_format` and `unit_test` jobs run faster
- Remove linting checks for test commands in `Makefile`
- Remove `INSTALL_STAMP` check from `integration-test` Make command